### PR TITLE
libFiltrs 2.0 v3.6 - Update for Summerset PTS API100023 (new filters for jewelry)

### DIFF
--- a/LibFilters-2.0/LibFilters-2.0.lua
+++ b/LibFilters-2.0/LibFilters-2.0.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = "LibFilters-2.0", 3.5
+local MAJOR, MINOR = "LibFilters-2.0", 3.6
 local LibFilters, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not LibFilters then return end
 
@@ -33,6 +33,16 @@ LF_QUICKSLOT             = 27
 LF_RETRAIT               = 28
 LF_HOUSE_BANK_WITHDRAW   = 29
 LF_HOUSE_BANK_DEPOSIT    = 30
+LF_JEWELRY_REFINE        = 31
+LF_JEWELRY_CREATION      = 32
+LF_JEWELRY_DECONSTRUCT   = 33
+LF_JEWELRY_IMPROVEMENT   = 34
+LF_JEWELRY_RESEARCH      = 35
+LF_FILTER_MAX            = LF_JEWELRY_RESEARCH
+
+function LibFilters:GetMaxFilter()
+    return LF_FILTER_MAX
+end
 
 LibFilters.isInitialized = false
 LibFilters.filters = {
@@ -66,6 +76,11 @@ LibFilters.filters = {
     [LF_RETRAIT] = {},
     [LF_HOUSE_BANK_WITHDRAW] = {},
     [LF_HOUSE_BANK_DEPOSIT] = {},
+    [LF_JEWELRY_REFINE]      = {},
+    [LF_JEWELRY_CREATION]    = {},
+    [LF_JEWELRY_DECONSTRUCT] = {},
+    [LF_JEWELRY_IMPROVEMENT] = {},
+    [LF_JEWELRY_RESEARCH]    = {},
 }
 local filters = LibFilters.filters
 
@@ -100,6 +115,11 @@ local filterTypeToUpdaterName = {
     [LF_RETRAIT] = "RETRAIT",
     [LF_HOUSE_BANK_WITHDRAW] = "HOUSE_BANK_WITHDRAW",
     [LF_HOUSE_BANK_DEPOSIT] = "INVENTORY",
+    [LF_JEWELRY_REFINE]      = "SMITHING_REFINE",
+    [LF_JEWELRY_CREATION]    = "SMITHING_CREATION",
+    [LF_JEWELRY_DECONSTRUCT] = "SMITHING_DECONSTRUCT",
+    [LF_JEWELRY_IMPROVEMENT] = "SMITHING_IMPROVEMENT",
+    [LF_JEWELRY_RESEARCH]    = "SMITHING_RESEARCH",
 }
 
 --if the mouse is enabled, cycle its state to refresh the integrity of the control beneath it
@@ -233,6 +253,10 @@ local function HookAdditionalFilters()
     LibFilters:HookAdditionalFilter(LF_SMITHING_DECONSTRUCT, SMITHING.deconstructionPanel.inventory)
     LibFilters:HookAdditionalFilter(LF_SMITHING_IMPROVEMENT, SMITHING.improvementPanel.inventory)
     LibFilters:HookAdditionalFilter(LF_SMITHING_RESEARCH, SMITHING.researchPanel)
+    --LibFilters:HookAdditionalFilter(LF_JEWELRY_CREATION, )
+    LibFilters:HookAdditionalFilter(LF_JEWELRY_DECONSTRUCT, SMITHING.deconstructionPanel.inventory)
+    LibFilters:HookAdditionalFilter(LF_JEWELRY_IMPROVEMENT, SMITHING.improvementPanel.inventory)
+    LibFilters:HookAdditionalFilter(LF_JEWELRY_RESEARCH, SMITHING.researchPanel)
 
     LibFilters:HookAdditionalFilter(LF_ALCHEMY_CREATION, ALCHEMY.inventory)
 


### PR DESCRIPTION
-Added new filters: LF_JEWELRY_CREATE, LF_JEWELRY_REFINE, LF_JEWELRY_DECONSTRUCT, LF_JEWELRY_IMPROVE, LF_JEWELRY_RESEARCH
-Added filter LF_FILTER_MAX which points to the current maximum filter ID + function LibFilters:GetMaxFilter() which returns the value.

Differences between LF_SMITHING* and LF_JEWELRY* must be made within the addons via function GetCraftingInteractionType() -> CRAFTING_TYPE_JEWELRYCRAFTING (7) is the value for the jewelry stuff activated!